### PR TITLE
fix: Automatically update major version tags when publishing

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,7 +1,6 @@
 name: Keep the versions up-to-date
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -3,7 +3,7 @@ name: Keep the versions up-to-date
 on:
   workflow_dispatch:
   release:
-    types: [published, edited]
+    types: [published]
 
 jobs:
   actions-tagger:

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: streetsidesoftware/cspell-action@v1.0.1
+      - uses: streetsidesoftware/cspell-action@v1
 ```
 
 ## Usage
 
 ```yaml
-- uses: streetsidesoftware/cspell-action@v1.0.1
+- uses: streetsidesoftware/cspell-action@v1
   with:
     # Github token used to fetch the list of changed files in the commit.
     # Default: ${{ github.token }}


### PR DESCRIPTION
Fix: #523