### PR TITLE
feat: output spell checking result

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -53,3 +53,22 @@ jobs:
             **
             .*/**
           verbose: true
+
+  test-action-files-with-issues: # run the action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        id: cspell-action
+        with:
+          incremental_files_only: false
+          files: |
+            fixtures/**
+          config: ./fixtures/cspell.json
+          strict: false
+          inline: none
+      - name: Show Results
+        env:
+          outputs: ${{ toJSON(steps.cspell-action.outputs) }}
+        run: |
+          echo "$outputs"

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -11,12 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        id: cspell-action
 
   test-action-with-file: # run the action
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        id: cspell-action
         with:
           files: |
             **/*.ts
@@ -27,17 +29,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        id: cspell-action
         with:
           incremental_files_only: false
           files: |
             **
             .*/**
+      - name: Show Results
+        env:
+          outputs: ${{ toJSON(steps.cspell-action.outputs) }}
+        run: |
+          echo "$outputs"
 
   test-action-no-increment-verbose: # run the action
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        id: cspell-action
         with:
           incremental_files_only: false
           files: |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ outputs:
       The JSON encoded results.
 ```
 
+Example Output:
+
+```json
+{
+  "success": "false",
+  "number_of_files_checked": "3",
+  "number_of_issues": "2",
+  "number_of_files_with_issues": "1",
+  "files_with_issues": "[\"src/withErrors.ts\"]",
+  "result": "{\"success\":false,\"number_of_issues\":2,\"number_of_files_checked\":3,\"files_with_issues\":[\"src/withErrors.ts\"]}"
+}
+```
+
 <!---
 cspell:ignore medicalterms
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ const cspell = {
 module.exports = cspell;
 ```
 
+## Outputs
+
+```yaml
+outputs:
+  success:
+    description: |
+      "true" if no spelling issues were found, otherwise "false".
+  number_of_files_checked:
+    description: |
+      The actual number of files that were checked.
+  number_of_issues:
+    description: |
+      The number of issues found.
+  number_of_files_with_issues:
+    description: |
+      The number of files that had issues.
+  files_with_issues:
+    description: |
+      List of files with issues. Use `fromJSON()` to decode.
+      The files are relative to the repository root.
+  results:
+    description: |
+      The JSON encoded results.
+```
+
 <!---
 cspell:ignore medicalterms
 

--- a/action-src/src/__snapshots__/action.test.ts.snap
+++ b/action-src/src/__snapshots__/action.test.ts.snap
@@ -10,3 +10,96 @@ Array [
 `;
 
 exports[`Validate Action check all **/*.md 1`] = `Array []`;
+
+exports[`Validate Action check files with issues fixtures/sampleCode/** 1`] = `
+Array [
+  "../fixtures/sampleCode/samples_with_errors/withErrors.ts:5:19 Unknown word (Functon)",
+  "../fixtures/sampleCode/samples_with_errors/withErrors.ts:5:27 Unknown word (countt)",
+]
+`;
+
+exports[`Validate Action check files with issues fixtures/sampleCode/** 2`] = `Array []`;
+
+exports[`Validate Action check files with issues fixtures/sampleCode/** 3`] = `
+Array [
+  Array [
+    "Pull Request
+",
+  ],
+  Array [
+    "::warning file=../fixtures/sampleCode/samples_with_errors/withErrors.ts,line=5,col=19::Unknown word (Functon)
+",
+  ],
+  Array [
+    "::warning file=../fixtures/sampleCode/samples_with_errors/withErrors.ts,line=5,col=27::Unknown word (countt)
+",
+  ],
+  Array [
+    "Files checked: 2, Issues found: 2 in 1 files.
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=success::false
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=number_of_files_checked::2
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=number_of_issues::2
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=number_of_files_with_issues::1
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=files_with_issues::[\\"../fixtures/sampleCode/samples_with_errors/withErrors.ts\\"]
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::set-output name=result::{\\"success\\":false,\\"number_of_issues\\":2,\\"number_of_files_checked\\":2,\\"files_with_issues\\":[\\"../fixtures/sampleCode/samples_with_errors/withErrors.ts\\"]}
+",
+  ],
+]
+`;
+
+exports[`Validate Action check files with issues fixtures/sampleCode/** 4`] = `
+Array [
+  "Pull Request",
+  "::warning file=../fixtures/sampleCode/samples_with_errors/withErrors.ts,line=5,col=19::Unknown word (Functon)",
+  "::warning file=../fixtures/sampleCode/samples_with_errors/withErrors.ts,line=5,col=27::Unknown word (countt)",
+  "Files checked: 2, Issues found: 2 in 1 files.",
+  "::set-output name=success::false",
+  "::set-output name=number_of_files_checked::2",
+  "::set-output name=number_of_issues::2",
+  "::set-output name=number_of_files_with_issues::1",
+  "::set-output name=files_with_issues::[\\"../fixtures/sampleCode/samples_with_errors/withErrors.ts\\"]",
+  "::set-output name=result::{\\"success\\":false,\\"number_of_issues\\":2,\\"number_of_files_checked\\":2,\\"files_with_issues\\":[\\"../fixtures/sampleCode/samples_with_errors/withErrors.ts\\"]}",
+]
+`;

--- a/action-src/src/action.test.ts
+++ b/action-src/src/action.test.ts
@@ -86,10 +86,31 @@ describe('Validate Action', () => {
                 INPUT_INCREMENTAL_FILES_ONLY: 'false',
             });
             const octokit = createOctokit();
-            expect.assertions(3);
             await expect(action(context, octokit)).resolves.toBe(expected);
             expect(warnings).toMatchSnapshot();
             expect(spyStdout).toHaveBeenCalled();
+        },
+        timeout
+    );
+
+    test.each`
+        files                       | expected
+        ${'fixtures/sampleCode/**'} | ${false}
+    `(
+        'check files with issues $files',
+        async ({ files, expected }) => {
+            const warnings: string[] = [];
+            spyWarn.mockImplementation((msg: string) => warnings.push(msg));
+            const context = createContextFromFile('pull_request_with_files.json', {
+                INPUT_FILES: files,
+                INPUT_INCREMENTAL_FILES_ONLY: 'false',
+            });
+            const octokit = createOctokit();
+            await expect(action(context, octokit)).resolves.toBe(expected);
+            expect(warnings).toMatchSnapshot();
+            expect(spyLog.mock.calls).toMatchSnapshot();
+            expect(spyStdout.mock.calls).toMatchSnapshot();
+            expect(spyStdout.mock.calls.map((call) => call.join('').trim()).filter((a) => !!a)).toMatchSnapshot();
         },
         timeout
     );

--- a/action-src/src/action.ts
+++ b/action-src/src/action.ts
@@ -151,11 +151,7 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     const message = `Files checked: ${result.files}, Issues found: ${result.issues} in ${result.filesWithIssues.size} files.`;
     core.info(message);
 
-    core.setOutput('success', !result.issues);
-    core.setOutput('files_checked', result.files);
-    core.setOutput('number_of_issues', result.issues);
-    core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
-    core.setOutput('files_with_issues', normalizeFiles(result.filesWithIssues).slice(0, 1000));
+    outputResult(result);
 
     const fnS = (n: number) => (n === 1 ? '' : 's');
 
@@ -168,6 +164,27 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     }
 
     return !(result.issues + result.errors);
+}
+
+function outputResult(runResult: RunResult) {
+    const result = normalizeResult(runResult);
+
+    core.setOutput('success', result.success);
+    core.setOutput('number_of_files_checked', result.number_of_files_checked);
+    core.setOutput('number_of_issues', result.number_of_issues);
+    core.setOutput('number_of_files_with_issues', result.files_with_issues.length);
+    core.setOutput('files_with_issues', normalizeFiles(result.files_with_issues));
+    core.setOutput('result', result);
+}
+
+function normalizeResult(result: RunResult) {
+    const { issues: number_of_issues, files: number_of_files_checked, filesWithIssues } = result;
+    return {
+        success: !number_of_issues,
+        number_of_issues,
+        number_of_files_checked,
+        files_with_issues: normalizeFiles(filesWithIssues).slice(0, 1000),
+    };
 }
 
 function normalizeFiles(files: Iterable<string>): string[] {

--- a/action-src/src/action.ts
+++ b/action-src/src/action.ts
@@ -150,6 +150,12 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     const message = `Files checked: ${result.files}, Issues found: ${result.issues} in ${result.filesWithIssues.size} files.`;
     core.info(message);
 
+    core.setOutput('success', !result.issues);
+    core.setOutput('files_checked', result.files);
+    core.setOutput('number_of_issues', result.issues);
+    core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
+    core.setOutput('files_with_issues', [...result.filesWithIssues].slice(0, 1000));
+
     const fnS = (n: number) => (n === 1 ? '' : 's');
 
     if (params.strict === 'true' && result.issues) {

--- a/action-src/src/action.ts
+++ b/action-src/src/action.ts
@@ -3,14 +3,13 @@ import { Context as GitHubContext } from '@actions/github/lib/context';
 import { Octokit } from '@octokit/core';
 import { RunResult } from 'cspell';
 import * as glob from 'cspell-glob';
-import { format } from 'util';
-import { AppError } from './error';
-import { fetchFilesForCommits, getPullRequestFiles } from './github';
+import * as path from 'path';
 import { ActionParams, validateActionParams } from './ActionParams';
+import { AppError } from './error';
 import { getActionParams } from './getActionParams';
+import { fetchFilesForCommits, getPullRequestFiles } from './github';
 import { CSpellReporterForGithubAction } from './reporter';
 import { lint, LintOptions } from './spell';
-import * as path from 'path';
 
 interface Context {
     githubContext: GitHubContext;
@@ -141,7 +140,6 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     };
 
     core.info(friendlyEventName(eventName));
-    core.debug(format('Options: %o', params));
     const files = await gatherFilesFromContext(context);
     const result = await checkSpelling(params, [...files]);
     if (result === true) {

--- a/action-src/src/action.ts
+++ b/action-src/src/action.ts
@@ -10,6 +10,7 @@ import { ActionParams, validateActionParams } from './ActionParams';
 import { getActionParams } from './getActionParams';
 import { CSpellReporterForGithubAction } from './reporter';
 import { lint, LintOptions } from './spell';
+import * as path from 'path';
 
 interface Context {
     githubContext: GitHubContext;
@@ -154,7 +155,7 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     core.setOutput('files_checked', result.files);
     core.setOutput('number_of_issues', result.issues);
     core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
-    core.setOutput('files_with_issues', [...result.filesWithIssues].slice(0, 1000));
+    core.setOutput('files_with_issues', normalizeFiles(result.filesWithIssues).slice(0, 1000));
 
     const fnS = (n: number) => (n === 1 ? '' : 's');
 
@@ -167,4 +168,9 @@ export async function action(githubContext: GitHubContext, octokit: Octokit): Pr
     }
 
     return !(result.issues + result.errors);
+}
+
+function normalizeFiles(files: Iterable<string>): string[] {
+    const cwd = process.cwd();
+    return [...files].map((file) => path.relative(cwd, file));
 }

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,23 @@ inputs:
 outputs:
   success:
     description: |
-      "true" if no spelling issues were found.
+      "true" if no spelling issues were found, otherwise "false".
+  number_of_files_checked:
+    description: |
+      The actual number of files that were checked.
+  number_of_issues:
+    description: |
+      The number of issues found.
+  number_of_files_with_issues:
+    description: |
+      The number of files that had issues.
+  files_with_issues:
+    description: |
+      List of files with issues. Use `fromJSON()` to decode.
+      The files are relative to the repository root.
+  results:
+    description: |
+      The JSON encoded results.
 
 runs:
   using: "node16"

--- a/action.yaml
+++ b/action.yaml
@@ -49,6 +49,11 @@ inputs:
       Allowed values are: true, false
     default: "false"
     required: false
+outputs:
+  success:
+    description: |
+      "true" if no spelling issues were found.
+
 runs:
   using: "node16"
   main: "./action/lib/main_root.js"

--- a/action/lib/action.js
+++ b/action/lib/action.js
@@ -138,11 +138,7 @@ async function action(githubContext, octokit) {
     }
     const message = `Files checked: ${result.files}, Issues found: ${result.issues} in ${result.filesWithIssues.size} files.`;
     core.info(message);
-    core.setOutput('success', !result.issues);
-    core.setOutput('files_checked', result.files);
-    core.setOutput('number_of_issues', result.issues);
-    core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
-    core.setOutput('files_with_issues', normalizeFiles(result.filesWithIssues).slice(0, 1000));
+    outputResult(result);
     const fnS = (n) => (n === 1 ? '' : 's');
     if (params.strict === 'true' && result.issues) {
         const filesWithIssues = result.filesWithIssues.size;
@@ -152,6 +148,24 @@ async function action(githubContext, octokit) {
     return !(result.issues + result.errors);
 }
 exports.action = action;
+function outputResult(runResult) {
+    const result = normalizeResult(runResult);
+    core.setOutput('success', result.success);
+    core.setOutput('number_of_files_checked', result.number_of_files_checked);
+    core.setOutput('number_of_issues', result.number_of_issues);
+    core.setOutput('number_of_files_with_issues', result.files_with_issues.length);
+    core.setOutput('files_with_issues', normalizeFiles(result.files_with_issues));
+    core.setOutput('result', result);
+}
+function normalizeResult(result) {
+    const { issues: number_of_issues, files: number_of_files_checked, filesWithIssues } = result;
+    return {
+        success: !number_of_issues,
+        number_of_issues,
+        number_of_files_checked,
+        files_with_issues: normalizeFiles(filesWithIssues).slice(0, 1000),
+    };
+}
 function normalizeFiles(files) {
     const cwd = process.cwd();
     return [...files].map((file) => path.relative(cwd, file));

--- a/action/lib/action.js
+++ b/action/lib/action.js
@@ -137,6 +137,11 @@ async function action(githubContext, octokit) {
     }
     const message = `Files checked: ${result.files}, Issues found: ${result.issues} in ${result.filesWithIssues.size} files.`;
     core.info(message);
+    core.setOutput('success', !result.issues);
+    core.setOutput('files_checked', result.files);
+    core.setOutput('number_of_issues', result.issues);
+    core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
+    core.setOutput('files_with_issues', [...result.filesWithIssues].slice(0, 1000));
     const fnS = (n) => (n === 1 ? '' : 's');
     if (params.strict === 'true' && result.issues) {
         const filesWithIssues = result.filesWithIssues.size;

--- a/action/lib/action.js
+++ b/action/lib/action.js
@@ -26,14 +26,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.action = void 0;
 const core = __importStar(require("@actions/core"));
 const glob = __importStar(require("cspell-glob"));
-const util_1 = require("util");
-const error_1 = require("./error");
-const github_1 = require("./github");
+const path = __importStar(require("path"));
 const ActionParams_1 = require("./ActionParams");
+const error_1 = require("./error");
 const getActionParams_1 = require("./getActionParams");
+const github_1 = require("./github");
 const reporter_1 = require("./reporter");
 const spell_1 = require("./spell");
-const path = __importStar(require("path"));
 const supportedEvents = new Set(['push', 'pull_request']);
 async function gatherPullRequestFiles(context) {
     var _a;
@@ -130,7 +129,6 @@ async function action(githubContext, octokit) {
         useEventFiles: params.incremental_files_only === 'true',
     };
     core.info(friendlyEventName(eventName));
-    core.debug((0, util_1.format)('Options: %o', params));
     const files = await gatherFilesFromContext(context);
     const result = await checkSpelling(params, [...files]);
     if (result === true) {

--- a/action/lib/action.js
+++ b/action/lib/action.js
@@ -33,6 +33,7 @@ const ActionParams_1 = require("./ActionParams");
 const getActionParams_1 = require("./getActionParams");
 const reporter_1 = require("./reporter");
 const spell_1 = require("./spell");
+const path = __importStar(require("path"));
 const supportedEvents = new Set(['push', 'pull_request']);
 async function gatherPullRequestFiles(context) {
     var _a;
@@ -141,7 +142,7 @@ async function action(githubContext, octokit) {
     core.setOutput('files_checked', result.files);
     core.setOutput('number_of_issues', result.issues);
     core.setOutput('number_of_files_with_issues', result.filesWithIssues.size);
-    core.setOutput('files_with_issues', [...result.filesWithIssues].slice(0, 1000));
+    core.setOutput('files_with_issues', normalizeFiles(result.filesWithIssues).slice(0, 1000));
     const fnS = (n) => (n === 1 ? '' : 's');
     if (params.strict === 'true' && result.issues) {
         const filesWithIssues = result.filesWithIssues.size;
@@ -151,3 +152,7 @@ async function action(githubContext, octokit) {
     return !(result.issues + result.errors);
 }
 exports.action = action;
+function normalizeFiles(files) {
+    const cwd = process.cwd();
+    return [...files].map((file) => path.relative(cwd, file));
+}


### PR DESCRIPTION
Output the results of the action:

```yaml
outputs:
  success:
    description: |
      "true" if no spelling issues were found, otherwise "false".
  number_of_files_checked:
    description: |
      The actual number of files that were checked.
  number_of_issues:
    description: |
      The number of issues found.
  number_of_files_with_issues:
    description: |
      The number of files that had issues.
  files_with_issues:
    description: |
      List of files with issues. Use `fromJSON()` to decode.
      The files are relative to the repository root.
  results:
    description: |
      The JSON encoded results.
```

Example Output:
```json
{
  "success": "false",
  "number_of_files_checked": "3",
  "number_of_issues": "2",
  "number_of_files_with_issues": "1",
  "files_with_issues": "[\"src/withErrors.ts\"]",
  "result": "{\"success\":false,\"number_of_issues\":2,\"number_of_files_checked\":3,\"files_with_issues\":[\"src/withErrors.ts\"]}"
}
```
