### PR TITLE
chore: lock vscode-uri to 3.0.4

### DIFF
--- a/action-src/package.json
+++ b/action-src/package.json
@@ -39,6 +39,6 @@
     "@octokit/rest": "^19.0.4",
     "cspell": "^6.10.0",
     "cspell-glob": "^6.10.0",
-    "vscode-uri": "^3.0.4"
+    "vscode-uri": "3.0.4"
   }
 }

--- a/action/package.json
+++ b/action/package.json
@@ -16,6 +16,6 @@
     "@octokit/rest": "^19.0.4",
     "cspell": "^6.10.0",
     "cspell-glob": "^6.10.0",
-    "vscode-uri": "^3.0.4"
+    "vscode-uri": "3.0.4"
   }
 }


### PR DESCRIPTION
To be reverted when https://github.com/microsoft/vscode/issues/161166 is fixed.