### PR TITLE
feat: expose the `report` argument via the action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ jobs:
 
     # Use the `files` setting found in the CSpell configuration instead of `input.files`.
     use_cspell_files: false
+
+    # Set how unknown words are reported.
+    # Allowed values are: all, simple, typos, flagged
+    # Default: all
+    report: all
 ```
 
 ## Yarn 2 - PlugNPlay

--- a/action-src/src/ActionParams.ts
+++ b/action-src/src/ActionParams.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 
 import { AppError } from './error.js';
+import { ReportChoices } from './spell.js';
 
 /**
  * [Workflow commands for GitHub Actions - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter)
@@ -62,6 +63,16 @@ export interface ActionParams {
      * @default 'false'
      */
     use_cspell_files: TrueFalse;
+
+    /**
+     * Set how unknown words are reported.
+     * 'all' - all issues are reported.
+     * 'simple' - only unknown words are reported.
+     * 'typos' - only typos are reported.
+     * 'flagged' - only flagged words are reported.
+     * @default 'all'
+     */
+    report: ReportChoices;
 }
 
 const defaultActionParams: ActionParams = {
@@ -76,6 +87,7 @@ const defaultActionParams: ActionParams = {
     check_dot_files: 'explicit',
     use_cspell_files: 'false',
     suggestions: 'false',
+    report: 'all',
 };
 
 type ValidationFunction = (params: ActionParamsInput) => string | undefined;
@@ -134,6 +146,7 @@ export function validateActionParams(
         validateTrueFalse('use_cspell_files'),
         validateTrueFalse('suggestions'),
         validateOptions('check_dot_files', ['true', 'false', 'explicit']),
+        validateOptions('report', ['all', 'simple', 'typos', 'flagged']),
     ];
     const success = validations
         .map((fn) => fn(params))

--- a/action-src/src/checkSpelling.ts
+++ b/action-src/src/checkSpelling.ts
@@ -92,6 +92,7 @@ async function checkSpelling(
         checkDotFiles: checkDotMap[params.check_dot_files],
         files,
         showSuggestions: params.suggestions === 'true',
+        report: params.report,
     };
 
     const reporterOptions = {

--- a/action-src/src/getActionParams.ts
+++ b/action-src/src/getActionParams.ts
@@ -16,6 +16,7 @@ export function getActionParams(): ActionParamsInput {
         check_dot_files: tf(getInput('check_dot_files')),
         use_cspell_files: tf(getInput('use_cspell_files')),
         suggestions: tf(getInput('suggestions')),
+        report: getInput('report').toLowerCase(),
     };
     return applyDefaults(params);
 }

--- a/action-src/src/spell.ts
+++ b/action-src/src/spell.ts
@@ -1,6 +1,7 @@
 import type { CSpellReporter } from 'cspell';
 import { type CSpellApplicationOptions, lint as cspellAppLint } from 'cspell';
 
+export type ReportChoices = 'all' | 'simple' | 'typos' | 'flagged';
 export interface LintOptions {
     root: string;
     config?: string;
@@ -13,6 +14,7 @@ export interface LintOptions {
     checkDotFiles: boolean | undefined;
     files?: string[] | undefined;
     showSuggestions?: boolean;
+    report?: ReportChoices | undefined;
 }
 
 /**
@@ -22,7 +24,7 @@ export interface LintOptions {
  * @param reporter - reporter to use.
  */
 export async function lint(globs: string[], lintOptions: LintOptions, reporter: CSpellReporter): Promise<void> {
-    const { root, config, checkDotFiles, files, showSuggestions } = lintOptions;
+    const { root, config, checkDotFiles, files, showSuggestions, report } = lintOptions;
     // It is expected that `files` in the configuration will be used to filter the files.
     const mustFindFiles = !files;
     const options: CSpellApplicationOptions = {
@@ -32,6 +34,7 @@ export async function lint(globs: string[], lintOptions: LintOptions, reporter: 
         // filterFiles: files ? false : undefined,
         mustFindFiles,
         showSuggestions,
+        report,
     };
 
     if (checkDotFiles) {

--- a/action.yaml
+++ b/action.yaml
@@ -65,6 +65,15 @@ inputs:
       - "false" - Use the `input.files` setting.
     default: "false"
     required: false
+  report:
+    description: |
+      Set how unknown words are reported.
+      - "all" - all issues are reported.
+      - "simple" - only unknown words are reported.
+      - "typos" - only typos are reported.
+      - "flagged" - only flagged words are reported.
+    default: "all"
+    required: false
 
 outputs:
   success:

--- a/action/lib/main_root.cjs
+++ b/action/lib/main_root.cjs
@@ -38749,7 +38749,8 @@ var defaultActionParams = {
   verbose: "false",
   check_dot_files: "explicit",
   use_cspell_files: "false",
-  suggestions: "false"
+  suggestions: "false",
+  report: "all"
 };
 function applyDefaults(params) {
   const results = { ...defaultActionParams, ...params };
@@ -38790,7 +38791,8 @@ function validateActionParams(params, logError2) {
     validateTrueFalse("verbose"),
     validateTrueFalse("use_cspell_files"),
     validateTrueFalse("suggestions"),
-    validateOptions("check_dot_files", ["true", "false", "explicit"])
+    validateOptions("check_dot_files", ["true", "false", "explicit"]),
+    validateOptions("report", ["all", "simple", "typos", "flagged"])
   ];
   const success = validations.map((fn) => fn(params)).map((msg) => !msg || (logError2(msg), false)).reduce((a, b) => a && b, true);
   if (!success) {
@@ -65262,7 +65264,7 @@ function lint(fileGlobs, options, reporter) {
 
 // src/spell.ts
 async function lint2(globs, lintOptions, reporter) {
-  const { root, config, checkDotFiles, files, showSuggestions } = lintOptions;
+  const { root, config, checkDotFiles, files, showSuggestions, report } = lintOptions;
   const mustFindFiles = !files;
   const options = {
     root,
@@ -65270,7 +65272,8 @@ async function lint2(globs, lintOptions, reporter) {
     files,
     // filterFiles: files ? false : undefined,
     mustFindFiles,
-    showSuggestions
+    showSuggestions,
+    report
   };
   if (checkDotFiles) {
     options.dot = true;
@@ -65328,7 +65331,8 @@ async function checkSpelling(params, globs, files) {
     config: params.config || void 0,
     checkDotFiles: checkDotMap[params.check_dot_files],
     files,
-    showSuggestions: params.suggestions === "true"
+    showSuggestions: params.suggestions === "true",
+    report: params.report
   };
   const reporterOptions = {
     verbose: params.verbose === "true",

--- a/action/lib/main_root.cjs
+++ b/action/lib/main_root.cjs
@@ -65358,7 +65358,8 @@ function getActionParams() {
     verbose: tf((0, import_core3.getInput)("verbose")),
     check_dot_files: tf((0, import_core3.getInput)("check_dot_files")),
     use_cspell_files: tf((0, import_core3.getInput)("use_cspell_files")),
-    suggestions: tf((0, import_core3.getInput)("suggestions"))
+    suggestions: tf((0, import_core3.getInput)("suggestions")),
+    report: (0, import_core3.getInput)("report").toLowerCase()
   };
   return applyDefaults(params);
 }


### PR DESCRIPTION
The `report` argument of `cspell` allows setting how unknown words are reported. This is a useful setting that would allow using `cspell-action` to report only on typos rather than all unknown words.

As part of testing, I'm running the updated action in my organisations.